### PR TITLE
Removed the background-color for the cursor line on the editor.

### DIFF
--- a/stylesheets/base.less
+++ b/stylesheets/base.less
@@ -256,11 +256,6 @@
     border-color: @syntax-cursor-color;
   }
 
-  &.is-focused .line-number.cursor-line-no-selection,
-  &.is-focused .line.cursor-line {
-    background-color: #0d1319;
-  }
-
   // Gutter-related
   .gutter {
     background-color: @syntax-gutter-background-color;


### PR DESCRIPTION
It should resolve issue #5 where you couldn't see the selection background-color when using the React editor
